### PR TITLE
Add guides to full site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,6 +31,7 @@ url: "https://morskyjezek.github.io" # the base hostname & protocol for your sit
 github_username:  morskyjezek
 
 course_data_repo_link: https://github.com/morskyjezek/si667-2025
+course_data_download_link: https://github.com/morskyjezek/si667-2025/archive/refs/heads/main.zip
 site_jekyll_files: https://github.com/morskyjezek/si667-2025-activities
 syllabus_link: https://docs.google.com/document/d/1bVVZSABYmp2wdp-XDkY2KNNSwMsO6ZYpgKmhmjU91dE/edit?usp=sharing
 instructor_link: https://www.si.umich.edu/people/jesse-johnston

--- a/_includes/guides-list.html
+++ b/_includes/guides-list.html
@@ -1,6 +1,6 @@
 {% assign guides_list = site.posts | where: "categories", "guides" %}
+
 {% if guides_list.size > 0 %}
-<h2 class="post-list-heading" id="guides">Guides</h2>
 <ul class="post-list">
     {% for guide in guides_list %}
     <li>

--- a/_labs/2025-02-04-lab-4-key.md
+++ b/_labs/2025-02-04-lab-4-key.md
@@ -41,7 +41,7 @@ _When unzipped into a folder called `docx-unzipped`, the `docx` should have a di
     7 directories, 12 files
     ```
 2. When you opened the file in the Word editor, you may have noticed there is an image in the file. Can you find that image? (Hint, it's name is image1.png.) Where is that embedded image stored?  
-_The images is stored at `./word/media/iamge1.png` (where the `.` is the directory in which the `docx` was unzipped)._  
+_The images is stored at `./word/media/image1.png` (where the `.` is the directory in which the `docx` was unzipped)._  
 3. Can you find the original creation date of the file? Where (what file) contains that creation date, and where is it in the unzipped DOCX structure? (Hint, it's metadata and will be stored in an XML file, once the file is unzipped you can search files in VSCode with Ctrl + F.)  
 _Look in `./docProps/core.xml`. There, you should find the XML tag `dcterms:created`. In this tag, you should see a system timestamp that follows ISO 8601 standard format, which indicates that this document was created on October 14, 2015. Oh, by the way, it's DublinCore metadata!! 🎉🎉_
 4. Imagine you were a curator tasked with preserving access to this file. What functionalities do you think you would want to preserve? What software might be required to preserve this functionality?  

--- a/_posts/2025-02-03-guides-running-siegfried-brunnhilde.md
+++ b/_posts/2025-02-03-guides-running-siegfried-brunnhilde.md
@@ -1,0 +1,42 @@
+---
+layout:     post
+title:      "Running Siegfried & Brunnhilde"
+date:       2025-02-03
+categories: brunnhilde siegfried guides
+---
+
+This page contains the instructions for running tools that can help with file reporting. These are useful tools that can create some of the preservation description information, which might accompany an information package, and to create technical information that can be used for tracking file integrity and duplication.
+
+# Setup
+
+The following sections show how to get set up to run the file reporting tools.
+
+## Sample Files
+
+All of the activities will use the course's sample files, which you should have previously downloaded during class in January. If you didn't download them, have lost those files, or want a new copy, they are located in the course github repository, and you can download them all directly as a zip file at [{{ site.course_data_download_link }}]({{ site.course_data_download_link }}). Unzip that folder somewhere on your computer, for example in your `Desktop` or `Documents` folder. This should result in a folder named `si667-2025`, which will match the demonstrations below. (_Nota bene: the files below were recorded in 2023 and the folder in the video shows the year 2023 in its name._)
+
+# Install Siegfried
+
+To install Siegfried, follow the instructions at the tool's site: [https://www.itforarchivists.com/siegfried/#install](https://www.itforarchivists.com/siegfried/#install). These instructions work well if you're using a Unix-style system (such as a Linux machine or Mac OS). The instructions use another tool, HomeBrew, which is a useful utility to manage command line programs, and if you need that, see the program's homepage for good installation instructions (note that it will require an internet connection): [https://brew.sh/](https://brew.sh/).
+
+If you're running on a different style of system (like Windows), the instructions are a bit less specific. If you have had trouble following those instructions, [try these step-by-step instructions for Windows]({% post_url 2025-02-09-guide-installing-siegfried-windows-11 %}). Linux systems may require more modifications.
+
+# Install Brunnhilde
+
+Brunnhilde is a python-based tool, so you can install it as you would other Python extensions using `pip`. The process is explained on the tool's site: [https://github.com/tw4l/brunnhilde#installation](https://github.com/tw4l/brunnhilde#installation).
+
+If those instructions aren't working well, here is a [Windows-specific walkthrough of the installation process](https://docs.google.com/document/d/1LKZA3ahzkM-Ic7w17f-doHIA342oKoS8kxROPKYOtqI/edit?usp=sharing).  
+
+# Check if the tools are running
+
+This screencast shows how to see if the tools are running:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/z1GOoispJ5k?si=v13jCbDgm1nx6j1R" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+&nbsp;
+
+# Running `brunnhilde.py`
+
+This screencast explains how `brunnhilde.py` works and demonstrates how to run the command:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/yuZQmpnjKhE?si=zvCO1X2RUB8iCNSd" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/_posts/2025-02-09-guide-installing-siegfried-windows-11.md
+++ b/_posts/2025-02-09-guide-installing-siegfried-windows-11.md
@@ -1,0 +1,40 @@
+---
+layout: post
+title: Installing Siegfried (1.11.1) on Windows (11)
+timeframe: early February
+categories: guides windows siegfried
+---
+
+Siegfried is a tool that we can use to characterize files, and we can also use it to link file characterizations to the major file type registries, including the PUID (PRONOM Unique Identifier), FDD (Library of Congress Format Description Documents), and MIME Types (Multipurpose Internet Media Extensions, sometimes called Media Types). The goal is to create shared, reliable, and documented file format designations, when possible.
+
+The tool is available at [https://www.itforarchivists.com/siegfried/](https://www.itforarchivists.com/siegfried/). The tool is developed by Richard LeHane, who has posted instructions at that site on how to install the tool. These instructions augment those and aim to provide a step-by-step guide to getting started with Siegfried in a Windows environment.
+
+# Installation Step by Step
+
+1. You can download the files from the above website, or directly as a zipped file at [this link](https://github.com/richardlehane/siegfried/releases/tag/v1.11.1) (v. 1.11.1, as of June 2024).
+2. You need to designate a place on your computer to keep the unzipped files. These should be somewhere in your system directories. I tested the following option:  
+   1. Create a folder near your root directory called “utils”, which creates this path: `C:\utils`; within that, create a folder called “siegfried”, which creates this path: `C:\utils\siegfried`.
+      1. You can create this directory by: open a File Explorer window. Access the file path bar by typing `Alt + D`; in the file path bar, type "C:\".
+         ![][image1]  
+      2. Create a new directory by typing `Ctrl + Shift + N`, and type the name “utils”.
+         ![][image2]  
+3. Once you have the destination folder ready, unzip the file you downloaded in step 1\. (Do this by right clicking on the zip file in the location where it was downloaded, then click the “Extract All…” option.) A window appears that offers you to choose where the files will be extracted (unzipped); choose the default, which should be the current location. Open the unzipped folder. You should see two files: **sf** & **roy** (that you, [siegfried & roy](https://en.wikipedia.org/wiki/Siegfried_%26_Roy)? 🤷).
+   ![][image3]  
+4. Move both of these files to the directory you created in step 2\. That is, now both files should be visible at the path **C:\utils** . Like this:  
+   ![][image4]
+5. Final (multiphase) step. Now you need to ensure that the “utils” folder is visible to your system file path. (This step is outlined similarly [here](https://www.computerhope.com/issues/ch000549.htm).)   
+   1. Go to the Power User Task Menu by typing the `Windows key + X`.
+   2. In the Power User Task Menu, select the “System” option.  
+   3. Select “Advanced system settings” (under the “Related settings” heading).
+   4. In the window that opens, select the button that says “Environmental variables...”
+   5. (Almost there!) In the window that opens, look for the “System variables” box, select the line that says Path (or double click so it is highlighted), then select the button that says “New...” underneath that box.
+      ![][image5]  
+   6. In the (final!) window that appears, select the button that says “New”. Type your “utils” path into the box that opens with a cursor: it should say something like **C:\utils** & look like:  
+      ![][image6]  
+6. Okay, now the real final step: **restart**.
+   1. When you get back online, open a terminal window in VSCode. You should run the command **sf \-update** & receive a sort of confirmation message.  
+       ![][image7]  
+   2. If that doesn’t work, try running siegfried with the full path; in the Visual Studio Code bash terminal, for example if you moved the files to a folder named “siegfried” within the “utils” folder, run: **/c/utils/siegfried/sf.exe -update**
+   3. If you see “You are already up to date!” it’s working!
+      ![][image8]  
+   4. If you don’t see anything, or get an error message, don’t worry. We’ll have to take a closer look.

--- a/guides.md
+++ b/guides.md
@@ -1,0 +1,7 @@
+---
+layout: page
+title: Guides
+permalink: /guides/
+---
+
+{% include guides-list.html %}

--- a/index.markdown
+++ b/index.markdown
@@ -18,3 +18,9 @@ you will also find a link to the "key," which provides explanation
 and/or solutions for each question.
 
 {% include labs-table.html %}
+
+# Guides {#guides}
+
+Below is a list of guides that explain various tools and processes in more detail:
+
+{% include guides-list.html %}


### PR DESCRIPTION
This adds a guides page, and should show the guides list on the main page. 
this also adds two new guides, an overview of installing siegfried & brunnhilde, plus details on installing siegon windows